### PR TITLE
Add upgrade output and show options commands

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -33,6 +33,8 @@ func New() *cobra.Command {
 	cmd.AddCommand(newCreate())
 	cmd.AddCommand(newAdd())
 	cmd.AddCommand(newUpgrade())
+	cmd.AddCommand(newEnvironments())
+	cmd.AddCommand(newTemplates())
 
 	return cmd
 }

--- a/internal/cmd/environments.go
+++ b/internal/cmd/environments.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	jimmyv1 "github.com/silas/jimmy/internal/pb/jimmy/v1"
+)
+
+func newEnvironments() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "environments",
+		Short:   "Show environments",
+		Aliases: []string{"envs"},
+		Args:    args(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			printEnums(
+				cmd,
+				jimmyv1.Environment_name,
+				false,
+				jimmyv1.Environment_ALL,
+			)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	jimmyv1 "github.com/silas/jimmy/internal/pb/jimmy/v1"
+)
+
+func newTemplates() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "templates",
+		Short: "Show templates",
+		Args:  args(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			printEnums(
+				cmd,
+				jimmyv1.Template_name,
+				true,
+				jimmyv1.Template_CREATE_TABLE,
+			)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/silas/jimmy/internal/migrations"
 )
 
 func newUpgrade() *cobra.Command {
@@ -17,7 +21,22 @@ func newUpgrade() *cobra.Command {
 			}
 			defer m.Close()
 
-			return m.Upgrade(cmd.Context())
+			err = m.Upgrade(
+				cmd.Context(),
+				migrations.UpgradeOnStart(func(id int, name string) {
+					cmd.Println(fmt.Sprintf("migration[%d]: Running %q", id, name))
+				}),
+				migrations.UpgradeOnComplete(func(id int, name string) {
+					cmd.Println(fmt.Sprintf("migration[%d]: Completed", id))
+				}),
+			)
+			if err != nil {
+				return err
+			}
+
+			cmd.Println("Done")
+
+			return nil
 		},
 	}
 

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -186,3 +186,26 @@ func setupMigrationFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(flagTemplate, "t", "", "SQL template")
 	cmd.Flags().StringP(flagType, "", "", "type of statement (DDL, DML, PARTITIONED_DML)")
 }
+
+func printEnums[d ~int32](
+	cmd *cobra.Command,
+	enum map[int32]string,
+	skipFirst bool,
+	defaultValue d,
+) {
+	for i := range int32(len(enum)) {
+		if i == 0 && skipFirst {
+			continue
+		}
+
+		name := enum[i]
+		name = strings.ToLower(name)
+		name = strings.ReplaceAll(name, "_", "-")
+
+		if i == int32(defaultValue) {
+			cmd.Println(name, "(default)")
+		} else {
+			cmd.Println(name)
+		}
+	}
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -70,6 +71,23 @@ func (m *Migrations) MigrationPath(id int) string {
 	}
 
 	return filepath.Join(m.Config.Path, name)
+}
+
+func (m *Migrations) MigrationName(id int) string {
+	name := m.migrations[id]
+	if name == "" {
+		return ""
+	}
+
+	idx := strings.Index(name, "_")
+	if idx == -1 {
+		return ""
+	}
+
+	name = name[idx+1:]
+	name, _ = strings.CutSuffix(name, ".yaml")
+	name = strings.ReplaceAll(name, "_", " ")
+	return name
 }
 
 func (m *Migrations) InstancesName() string {


### PR DESCRIPTION
New functionality:

```sh
$ jimmy upgrade
migration[1]: Running "test"
migration[1]: Completed
Done

$ jimmy environments
all (default)
google-cloud
emulator

$ jimmy templates
create-table (default)
drop-table
add-column
...
```